### PR TITLE
Implement Reader, Writer, and Seek traits from std::io

### DIFF
--- a/src/physfs/file.rs
+++ b/src/physfs/file.rs
@@ -117,7 +117,7 @@ impl <'f> File<'f> {
 }
 
 impl <'f> Reader for File<'f> {
-    ///Reads from a file
+    /// Reads from a file
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
         let _g = PHYSFS_LOCK.lock();
         let ret = unsafe {
@@ -174,6 +174,17 @@ impl <'f> Seek for File<'f> {
 
     /// Seek to a new position within a file
     fn seek(&mut self, pos: i64, style: SeekStyle) -> IoResult<()> {
+        match style {
+            SeekStyle::SeekSet => {},
+            _ => {
+                return Err(IoError {
+                    kind: IoErrorKind::OtherIoError,
+                    desc: "PhysicsFS Error",
+                    detail: Some("Only std::io::SeekStyle::SeekSet is supported.".to_string()),
+                })
+            }
+        }
+
         let _g = PHYSFS_LOCK.lock();
         let ret = unsafe {
             PHYSFS_seek(

--- a/src/physfs/file.rs
+++ b/src/physfs/file.rs
@@ -3,6 +3,7 @@ use super::{PhysFSContext, PHYSFS_LOCK};
 use std::ffi::CString;
 use libc::{c_int, c_char, c_void};
 use std::io::{Reader, Writer, Seek, SeekStyle, IoResult, IoError, IoErrorKind};
+use std::mem;
 
 #[link(name = "physfs")]
 extern {
@@ -92,44 +93,6 @@ impl <'f> File<'f> {
         }
     }
 
-    /// Reads from a file.
-    pub fn read(&self, buf: &mut [u8], obj_size: u32, obj_count: u32) -> Result<u64, String> {
-        let _g = PHYSFS_LOCK.lock();
-        let ret = unsafe {
-            PHYSFS_read(
-                self.raw,
-                buf.as_ptr() as *mut c_void,
-                obj_size as PHYSFS_uint32,
-                obj_count as PHYSFS_uint32
-            )
-        };
-
-        match ret {
-            -1 => Err(PhysFSContext::get_last_error()),
-            _ => Ok(ret as u64)
-        }
-    }
-
-    /// Writes to a file.
-    /// This code performs no safety checks to ensure
-    /// that the buffer is the correct length.
-    pub fn write(&self, buf: &[u8], obj_size: u32, obj_count: u32) -> Result<u64, String> {
-        let _g = PHYSFS_LOCK.lock();
-        let ret = unsafe {
-            PHYSFS_write(
-                self.raw,
-                buf.as_ptr() as *const c_void,
-                obj_size as PHYSFS_uint32,
-                obj_count as PHYSFS_uint32
-            )
-        };
-
-        match ret {
-            -1 => Err(PhysFSContext::get_last_error()),
-            _ => Ok(ret as u64)
-        }
-    }
-
     /// Checks whether eof is reached or not.
     pub fn eof(&self) -> bool {
         let _g = PHYSFS_LOCK.lock();
@@ -149,6 +112,48 @@ impl <'f> File<'f> {
             Ok(len as u64)
         } else {
             Err(PhysFSContext::get_last_error())
+        }
+    }
+}
+
+impl <'f> Reader for File<'f> {
+    ///Reads from a file
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        let _g = PHYSFS_LOCK.lock();
+        let ret = unsafe {
+            PHYSFS_read(
+                self.raw,
+                buf.as_ptr() as *mut c_void,
+                mem::size_of::<u8>() as PHYSFS_uint32,
+                buf.len() as PHYSFS_uint32
+            )
+        };
+
+        match ret {
+            -1 => Err(physfs_error_as_ioerror()),
+            _ => Ok(ret as usize)
+        }
+    }
+}
+
+impl <'f> Writer for File<'f> {
+    /// Writes to a file.
+    /// This code performs no safety checks to ensure
+    /// that the buffer is the correct length.
+    fn write(&mut self, buf: &[u8]) -> IoResult<()> {
+        let _g = PHYSFS_LOCK.lock();
+        let ret = unsafe {
+            PHYSFS_write(
+                self.raw,
+                buf.as_ptr() as *const c_void,
+                mem::size_of::<u8>() as PHYSFS_uint32,
+                buf.len() as PHYSFS_uint32
+            )
+        };
+
+        match ret {
+            n if n < (buf.len() as PHYSFS_sint64)  => Err(physfs_error_as_ioerror()),
+            _ => Ok(())
         }
     }
 }

--- a/tests/directory/mod.rs
+++ b/tests/directory/mod.rs
@@ -17,7 +17,7 @@ fn read_file_from_directory() {
         _ => {}
     }
 
-    let file = match file::File::open(&con, "/test/directory/read.txt".to_string(), file::Mode::Read) {
+    let mut file = match file::File::open(&con, "/test/directory/read.txt".to_string(), file::Mode::Read) {
         Ok(f) => f,
         Err(msg) => panic!(msg)
     };
@@ -25,7 +25,7 @@ fn read_file_from_directory() {
     let mut bytes = [0u8; 32];
     let buf = bytes.as_mut_slice();
 
-    match file.read(buf, 1, 32) {
+    match file.read(buf) {
         Err(msg) => panic!(msg),
         _ => {}
     }
@@ -38,3 +38,4 @@ fn read_file_from_directory() {
 
     assert!(msg.as_slice() == "Read from me.");
 }
+


### PR DESCRIPTION
Implementing traits from std::io allow for easier interoperability of a physfs::File with other libraries (e.g. [image::load()](https://github.com/PistonDevelopers/image/blob/66f55358f41b97dae4441c0d2aee55caec3217d9/src/dynimage.rs#L522).