### PR TITLE
Use std::io::Result and std::path::Path where applicable.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![feature(env)]
 #![feature(io)]
 #![feature(libc)]
+#![feature(path)]
 #![feature(std_misc)]
 #![feature(unsafe_destructor)]
 extern crate libc;

--- a/src/physfs/file.rs
+++ b/src/physfs/file.rs
@@ -1,9 +1,10 @@
+use std::ffi::CString;
+use std::io::{Read, Write, Seek, SeekFrom, Result};
+use std::mem;
+use libc::{c_int, c_char, c_void};
 use primitives::*;
 use super::{PhysFSContext, PHYSFS_LOCK};
-use std::ffi::CString;
-use libc::{c_int, c_char, c_void};
-use std::io::{Read, Write, Seek, SeekFrom, Result, Error, ErrorKind};
-use std::mem;
+use super::util::physfs_error_as_io_error;
 
 #[link(name = "physfs")]
 extern {
@@ -62,12 +63,6 @@ pub struct File<'f> {
     raw: *const RawFile,
     mode: Mode,
     context: &'f PhysFSContext,
-}
-
-fn physfs_error_as_io_error() -> Error {
-    Error::new(ErrorKind::Other,
-               "PhysicsFS Error",
-               Some(PhysFSContext::get_last_error()))
 }
 
 impl <'f> File<'f> {

--- a/src/physfs/mod.rs
+++ b/src/physfs/mod.rs
@@ -1,4 +1,5 @@
 use std::ffi::{CString, c_str_to_bytes};
+use std::io::Result;
 use std::sync::{StaticMutex, MUTEX_INIT};
 use libc::{c_int, c_char};
 
@@ -6,6 +7,9 @@ use libc::{c_int, c_char};
 static PHYSFS_LOCK: StaticMutex = MUTEX_INIT;
 /// Keep track of the number of global contexts.
 static mut NUM_CONTEXTS: usize = 0;
+
+/// Utility
+mod util;
 /// File operations
 pub mod file;
 
@@ -30,6 +34,7 @@ extern {
     // Checks if a given path is a directory; returns nonzero if true
     fn PHYSFS_isDirectory(path: *const c_char) -> c_int;
 }
+
 /// The access point for PhysFS function calls.
 ///
 /// It aims to be thread-safe.
@@ -39,17 +44,17 @@ unsafe impl Send for PhysFSContext {}
 
 impl PhysFSContext {
     /// Creates a new PhysFS context.
-    pub fn new() -> Result<PhysFSContext, String> {
+    pub fn new() -> Result<PhysFSContext> {
         // grab the lock before doing any of this.
         let _g = PHYSFS_LOCK.lock();
 
         let con = PhysFSContext;
         match PhysFSContext::init() {
-            Err(msg) => Err(msg),
-            _ => { 
+            Err(e) => Err(e),
+            _ => {
                 // Everything's gone right so far
                 // now, increment the instance counter
-                unsafe { 
+                unsafe {
                     NUM_CONTEXTS += 1;
                 }
                 // and return the newly created context
@@ -59,7 +64,7 @@ impl PhysFSContext {
     }
 
     /// initializes the PhysFS library.
-    fn init() -> Result<(), String> {
+    fn init() -> Result<()> {
         // Initializing multiple times throws an error. So let's not!
         if PhysFSContext::is_init() { return Ok(()); }
 
@@ -70,7 +75,7 @@ impl PhysFSContext {
         let ret = unsafe { PHYSFS_init(c_arg0.as_ptr()) };
 
         match ret {
-            0 => Err(PhysFSContext::get_last_error()),
+            0 => Err(util::physfs_error_as_io_error()),
             _ => Ok(())
         }
     }
@@ -78,7 +83,7 @@ impl PhysFSContext {
     /// Checks if PhysFS is initialized
     pub fn is_init() -> bool
     {
-        unsafe {PHYSFS_isInit() != 0}
+        unsafe { PHYSFS_isInit() != 0 }
     }
 
     /// De-initializes PhysFS. It is recommended to close
@@ -93,7 +98,7 @@ impl PhysFSContext {
     }
     /// Adds an archive or directory to the search path.
     /// mount_point is the location in the tree to mount it to.
-    pub fn mount(&self, new_dir: String, mount_point: String, append_to_path: bool) -> Result<(), String>
+    pub fn mount(&self, new_dir: String, mount_point: String, append_to_path: bool) -> Result<()>
     {
         let _g = PHYSFS_LOCK.lock();
         let c_new_dir = CString::from_slice(new_dir.as_bytes());
@@ -105,38 +110,31 @@ impl PhysFSContext {
                 append_to_path as c_int
             )
         } {
-            0 => Err(PhysFSContext::get_last_error()),
+            0 => Err(util::physfs_error_as_io_error()),
             _ => Ok(())
         }
-
     }
 
     /// Gets the last error message in a human-readable format
-    /// This message may be localized, so do not expect it to 
+    /// This message may be localized, so do not expect it to
     /// match a specific string of characters.
-    pub fn get_last_error() -> String {
+    pub fn get_last_error() -> Option<String> {
         let ptr: *const c_char = unsafe {
-            PHYSFS_getLastError() 
+            PHYSFS_getLastError()
         };
         if ptr.is_null() {
-            return "".to_string();
+            return None
         }
 
-        let bytes: &[u8] = unsafe { c_str_to_bytes(&ptr) };
-
-        let mut err = String::new();
-
-        let it = bytes.iter().map(|&x| x as u8 as char);
-        for c in it {
-            err.push(c);
-        }
-        err
+        let buf: &[u8] = unsafe { c_str_to_bytes(&ptr) };
+        let err = String::from_utf8(buf.to_vec()).unwrap();
+        Some(err)
     }
 
     /// Sets a new write directory.
     /// This method will fail if the current write dir
     /// still has open files in it.
-    pub fn set_write_dir(&self, write_dir: &str) -> Result<(), String> {
+    pub fn set_write_dir(&self, write_dir: &str) -> Result<()> {
         let _g = PHYSFS_LOCK.lock();
         let write_dir = CString::from_slice(write_dir.as_bytes());
         let ret = unsafe {
@@ -144,13 +142,13 @@ impl PhysFSContext {
         };
 
         match ret {
-            0 => Err(PhysFSContext::get_last_error()),
+            0 => Err(util::physfs_error_as_io_error()),
             _ => Ok(())
         }
     }
 
     /// Creates a new dir relative to the write_dir.
-    pub fn mkdir(&self, dir_name: &str) -> Result<(), String> {
+    pub fn mkdir(&self, dir_name: &str) -> Result<()> {
         let _g = PHYSFS_LOCK.lock();
         let c_dir_name = CString::from_slice(dir_name.as_bytes());
         let ret = unsafe {
@@ -158,34 +156,32 @@ impl PhysFSContext {
         };
 
         match ret {
-            0 => Err(PhysFSContext::get_last_error()),
+            0 => Err(util::physfs_error_as_io_error()),
             _ => Ok(())
         }
     }
 
     /// Checks if given path exists
-    pub fn exists(&self, path: &str) -> Result<(), String> {
+    pub fn exists(&self, path: &str) -> Result<()> {
         let _g = PHYSFS_LOCK.lock();
         let c_path = CString::from_slice(path.as_bytes());
         let ret = unsafe { PHYSFS_exists(c_path.as_ptr()) };
 
-        if ret == 0 {
-            Err(PhysFSContext::get_last_error())
-        } else {
-            Ok(())
+        match ret {
+            0 => Err(util::physfs_error_as_io_error()),
+            _ => Ok(())
         }
     }
 
     /// Checks if given path is a directory
-    pub fn is_directory(&self, path: &str) -> Result<(), String> {
+    pub fn is_directory(&self, path: &str) -> Result<()> {
         let _g = PHYSFS_LOCK.lock();
         let c_path = CString::from_slice(path.as_bytes());
         let ret = unsafe { PHYSFS_isDirectory(c_path.as_ptr()) };
 
-        if ret == 0 {
-            Err(PhysFSContext::get_last_error())
-        } else {
-            Ok(())
+        match ret {
+            0 => Err(util::physfs_error_as_io_error()),
+            _ => Ok(())
         }
     }
 }
@@ -200,8 +196,9 @@ impl Drop for PhysFSContext {
             NUM_CONTEXTS -= 1;
         }
         // and de_init if there aren't any contexts left.
-        if unsafe{NUM_CONTEXTS == 0} {
+        if unsafe { NUM_CONTEXTS == 0 } {
             PhysFSContext::de_init();
         }
     }
 }
+

--- a/src/physfs/mod.rs
+++ b/src/physfs/mod.rs
@@ -1,5 +1,6 @@
 use std::ffi::{CString, c_str_to_bytes};
 use std::io::Result;
+use std::path::Path;
 use std::sync::{StaticMutex, MUTEX_INIT};
 use libc::{c_int, c_char};
 
@@ -98,10 +99,10 @@ impl PhysFSContext {
     }
     /// Adds an archive or directory to the search path.
     /// mount_point is the location in the tree to mount it to.
-    pub fn mount(&self, new_dir: String, mount_point: String, append_to_path: bool) -> Result<()>
+    pub fn mount(&self, new_dir: &Path, mount_point: String, append_to_path: bool) -> Result<()>
     {
         let _g = PHYSFS_LOCK.lock();
-        let c_new_dir = CString::from_slice(new_dir.as_bytes());
+        let c_new_dir = CString::from_slice(new_dir.to_str().unwrap().as_bytes());
         let c_mount_point = CString::from_slice(mount_point.as_bytes());
         match unsafe {
             PHYSFS_mount(
@@ -134,9 +135,9 @@ impl PhysFSContext {
     /// Sets a new write directory.
     /// This method will fail if the current write dir
     /// still has open files in it.
-    pub fn set_write_dir(&self, write_dir: &str) -> Result<()> {
+    pub fn set_write_dir(&self, write_dir: &Path) -> Result<()> {
         let _g = PHYSFS_LOCK.lock();
-        let write_dir = CString::from_slice(write_dir.as_bytes());
+        let write_dir = CString::from_slice(write_dir.to_str().unwrap().as_bytes());
         let ret = unsafe {
             PHYSFS_setWriteDir(write_dir.as_ptr())
         };

--- a/src/physfs/util.rs
+++ b/src/physfs/util.rs
@@ -1,0 +1,9 @@
+use std::io::{Error, ErrorKind};
+use super::PhysFSContext;
+
+pub fn physfs_error_as_io_error() -> Error {
+    Error::new(ErrorKind::Other,
+               "PhysicsFS Error",
+               PhysFSContext::get_last_error())
+}
+

--- a/tests/directory/mod.rs
+++ b/tests/directory/mod.rs
@@ -7,36 +7,36 @@ use std::io::Read;
 fn read_file_from_directory() {
     let _g = TEST_LOCK.lock();
     let con = match PhysFSContext::new() {
-        Err(msg) => panic!(msg),
+        Err(e) => panic!(e),
         Ok(con) => con
     };
 
     assert!(PhysFSContext::is_init());
 
     match con.mount(super::PATH_TO_HERE.to_string(), "/test/".to_string(), true) {
-        Err(msg) => panic!(msg),
+        Err(e) => panic!(e),
         _ => {}
     }
 
     let mut file = match file::File::open(&con, "/test/directory/read.txt".to_string(), file::Mode::Read) {
         Ok(f) => f,
-        Err(msg) => panic!(msg)
+        Err(e) => panic!(e)
     };
 
     let mut bytes = [0u8; 32];
     let buf = bytes.as_mut_slice();
 
     match file.read(buf) {
-        Err(msg) => panic!(msg),
+        Err(e) => panic!(e),
         _ => {}
     }
 
-    let mut msg = String::new();
+    let mut contents = String::new();
     for byte in buf.iter() {
         if *byte == 0 { break }
-        msg.push(*byte as char);
+        contents.push(*byte as char);
     }
 
-    assert!(msg.as_slice() == "Read from me.");
+    assert!(contents.as_slice() == "Read from me.");
 }
 

--- a/tests/directory/mod.rs
+++ b/tests/directory/mod.rs
@@ -1,7 +1,9 @@
+use std::io::Read;
+use std::path::Path;
+
 use physfs::PhysFSContext;
 use physfs::file;
 use super::TEST_LOCK;
-use std::io::Read;
 
 #[test]
 fn read_file_from_directory() {
@@ -13,7 +15,7 @@ fn read_file_from_directory() {
 
     assert!(PhysFSContext::is_init());
 
-    match con.mount(super::PATH_TO_HERE.to_string(), "/test/".to_string(), true) {
+    match con.mount(Path::new(super::PATH_TO_HERE), "/test/".to_string(), true) {
         Err(e) => panic!(e),
         _ => {}
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,6 @@
 #![feature(core)]
 #![feature(io)]
+#![feature(path)]
 #![feature(std_misc)]
 
 extern crate physfs;


### PR DESCRIPTION
PhysFSContext methods now return std::io::Result to match with physfs::file::File.
Change platform-dependent path arguments to std::path::Path.