### PR TITLE
Remove PhysFSContext as it gives the false illusion of being able to have multiple independent contexts.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![crate_type = "lib"]
 
 #![deny(missing_docs)]
-#![feature(core)]
 #![feature(env)]
 #![feature(io)]
 #![feature(libc)]

--- a/src/physfs/file.rs
+++ b/src/physfs/file.rs
@@ -1,9 +1,9 @@
+use libc::{c_int, c_char, c_void};
+use primitives::*;
 use std::ffi::CString;
 use std::io::{Read, Write, Seek, SeekFrom, Result};
 use std::mem;
-use libc::{c_int, c_char, c_void};
-use primitives::*;
-use super::{PhysFSContext, PHYSFS_LOCK};
+use std::sync::Mutex;
 use super::util::physfs_error_as_io_error;
 
 #[link(name = "physfs")]
@@ -59,17 +59,17 @@ struct RawFile {
 
 /// A file handle.
 #[allow(dead_code)]
-pub struct File<'f> {
+pub struct File {
     raw: *const RawFile,
     mode: Mode,
-    context: &'f PhysFSContext,
+    mutex: Mutex<u32>,
 }
 
-impl <'f> File<'f> {
+impl File {
     /// Opens a file with a specific mode.
-    pub fn open<'g>(context: &'g PhysFSContext, filename: String, mode: Mode) -> Result<File<'g>> {
-        let _g = PHYSFS_LOCK.lock();
-        let c_filename = CString::from_slice(filename.as_bytes());
+    pub fn open(filename: String, mode: Mode) -> Result<File> {
+        let c_filename = CString::new(filename.as_bytes()).unwrap();
+
         let raw = match mode {
             Mode::Append => unsafe{ PHYSFS_openAppend(c_filename.as_ptr()) },
             Mode::Read => unsafe{ PHYSFS_openRead(c_filename.as_ptr()) },
@@ -78,18 +78,22 @@ impl <'f> File<'f> {
 
         if raw.is_null() {
             Err(physfs_error_as_io_error())
-        }
-        else {
-            Ok(File{raw: raw, mode: mode, context: context})
+        } else {
+            Ok(File{
+                raw: raw,
+                mode: mode,
+                mutex: Mutex::new(0)
+            })
         }
     }
 
     /// Closes a file handle.
     fn close(&self) -> Result<()> {
-        let _g = PHYSFS_LOCK.lock();
-        match unsafe {
-            PHYSFS_close(self.raw)
-        } {
+        let _guard = self.mutex.lock().unwrap();
+
+        let ret = unsafe { PHYSFS_close(self.raw) };
+
+        match ret {
             0 => Err(physfs_error_as_io_error()),
             _ => Ok(())
         }
@@ -97,17 +101,15 @@ impl <'f> File<'f> {
 
     /// Checks whether eof is reached or not.
     pub fn eof(&self) -> bool {
-        let _g = PHYSFS_LOCK.lock();
-        let ret = unsafe {
-            PHYSFS_eof(self.raw)
-        };
+        let _guard = self.mutex.lock().unwrap();
 
-        ret != 0
+        unsafe { PHYSFS_eof(self.raw) != 0 }
     }
 
     /// Determine length of file, if possible
     pub fn len(&self) -> Result<u64> {
-        let _g = PHYSFS_LOCK.lock();
+        let _guard = self.mutex.lock().unwrap();
+
         let len = unsafe { PHYSFS_fileLength(self.raw) };
 
         if len >= 0 {
@@ -119,10 +121,9 @@ impl <'f> File<'f> {
 
     /// Determines current position within a file
     pub fn tell(&self) -> Result<u64> {
-        let _g = PHYSFS_LOCK.lock();
-        let ret = unsafe {
-            PHYSFS_tell(self.raw)
-        };
+        let _guard = self.mutex.lock().unwrap();
+
+        let ret = unsafe { PHYSFS_tell(self.raw) };
 
         match ret {
             -1 => Err(physfs_error_as_io_error()),
@@ -131,10 +132,11 @@ impl <'f> File<'f> {
     }
 }
 
-impl <'f> Read for File<'f> {
+impl Read for File {
     /// Reads from a file
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        let _g = PHYSFS_LOCK.lock();
+        let _guard = self.mutex.lock().unwrap();
+
         let ret = unsafe {
             PHYSFS_read(
                 self.raw,
@@ -151,12 +153,13 @@ impl <'f> Read for File<'f> {
     }
 }
 
-impl <'f> Write for File<'f> {
+impl Write for File {
     /// Writes to a file.
     /// This code performs no safety checks to ensure
     /// that the buffer is the correct length.
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
-        let _g = PHYSFS_LOCK.lock();
+        let _guard = self.mutex.lock().unwrap();
+
         let ret = unsafe {
             PHYSFS_write(
                 self.raw,
@@ -174,10 +177,9 @@ impl <'f> Write for File<'f> {
 
     /// Flushes a file if buffered; no-op if unbuffered.
     fn flush(&mut self) -> Result<()> {
-        let _g = PHYSFS_LOCK.lock();
-        let ret = unsafe {
-            PHYSFS_flush(self.raw)
-        };
+        let _guard = self.mutex.lock().unwrap();
+
+        let ret = unsafe { PHYSFS_flush(self.raw) };
 
         match ret {
             0 => Err(physfs_error_as_io_error()),
@@ -186,9 +188,10 @@ impl <'f> Write for File<'f> {
     }
 }
 
-impl <'f> Seek for File<'f> {
+impl Seek for File {
     /// Seek to a new position within a file
     fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+
         let seek_pos = match pos {
             SeekFrom::Start(n) => n as i64,
             SeekFrom::End(n) => {
@@ -201,16 +204,19 @@ impl <'f> Seek for File<'f> {
             },
         };
 
-        let _g = PHYSFS_LOCK.lock();
-        let result = unsafe {
-            PHYSFS_seek(
-                self.raw,
-                seek_pos as PHYSFS_uint64
-            )
-        };
+        {
+            let _guard = self.mutex.lock().unwrap();
 
-        if result == -1 {
-            return Err(physfs_error_as_io_error());
+            let ret = unsafe {
+                PHYSFS_seek(
+                    self.raw,
+                    seek_pos as PHYSFS_uint64
+                )
+            };
+
+            if ret == -1 {
+                return Err(physfs_error_as_io_error());
+            }
         }
 
         self.tell()
@@ -218,7 +224,7 @@ impl <'f> Seek for File<'f> {
 }
 
 #[unsafe_destructor]
-impl <'f> Drop for File<'f> {
+impl Drop for File {
     fn drop(&mut self) {
         match self.close() {
             _ => {}

--- a/src/physfs/file.rs
+++ b/src/physfs/file.rs
@@ -88,7 +88,7 @@ impl File {
     }
 
     /// Closes a file handle.
-    fn close(&self) -> Result<()> {
+    pub fn close(&self) -> Result<()> {
         let _guard = self.mutex.lock().unwrap();
 
         let ret = unsafe { PHYSFS_close(self.raw) };
@@ -191,7 +191,6 @@ impl Write for File {
 impl Seek for File {
     /// Seek to a new position within a file
     fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
-
         let seek_pos = match pos {
             SeekFrom::Start(n) => n as i64,
             SeekFrom::End(n) => {

--- a/src/physfs/mod.rs
+++ b/src/physfs/mod.rs
@@ -1,13 +1,9 @@
-use std::ffi::{CString, c_str_to_bytes};
+use std::env;
+use std::ffi::{CString, CStr};
 use std::io::Result;
 use std::path::Path;
-use std::sync::{StaticMutex, MUTEX_INIT};
+use std::ptr;
 use libc::{c_int, c_char};
-
-/// For locking physfs operations
-static PHYSFS_LOCK: StaticMutex = MUTEX_INIT;
-/// Keep track of the number of global contexts.
-static mut NUM_CONTEXTS: usize = 0;
 
 /// Utility
 mod util;
@@ -36,170 +32,121 @@ extern {
     fn PHYSFS_isDirectory(path: *const c_char) -> c_int;
 }
 
-/// The access point for PhysFS function calls.
-///
-/// It aims to be thread-safe.
-pub struct PhysFSContext;
+/// Initializes the PhysFS library.
+/// This must be called before using any other physfs methods (including physfs::File methods).
+pub fn init() -> Result<()> {
+    // Initializing multiple times throws an error. So let's not!
+    if is_init() { return Ok(()); }
 
-unsafe impl Send for PhysFSContext {}
+    let c_arg0 = match env::args().nth(0) {
+        Some(arg0) => CString::new(arg0.as_bytes()).unwrap().as_ptr(),
+        None => ptr::null()
+    };
 
-impl PhysFSContext {
-    /// Creates a new PhysFS context.
-    pub fn new() -> Result<PhysFSContext> {
-        // grab the lock before doing any of this.
-        let _g = PHYSFS_LOCK.lock();
+    let ret = unsafe { PHYSFS_init(c_arg0) };
 
-        let con = PhysFSContext;
-        match PhysFSContext::init() {
-            Err(e) => Err(e),
-            _ => {
-                // Everything's gone right so far
-                // now, increment the instance counter
-                unsafe {
-                    NUM_CONTEXTS += 1;
-                }
-                // and return the newly created context
-                Ok(con)
-            }
-        }
-    }
-
-    /// initializes the PhysFS library.
-    fn init() -> Result<()> {
-        // Initializing multiple times throws an error. So let's not!
-        if PhysFSContext::is_init() { return Ok(()); }
-
-        let mut args = ::std::env::args();
-        let default_arg0 = "".to_string();
-        let arg0 = args.next().unwrap_or(default_arg0);
-        let c_arg0 = CString::from_slice(arg0.as_bytes());
-        let ret = unsafe { PHYSFS_init(c_arg0.as_ptr()) };
-
-        match ret {
-            0 => Err(util::physfs_error_as_io_error()),
-            _ => Ok(())
-        }
-    }
-
-    /// Checks if PhysFS is initialized
-    pub fn is_init() -> bool
-    {
-        unsafe { PHYSFS_isInit() != 0 }
-    }
-
-    /// De-initializes PhysFS. It is recommended to close
-    /// all file handles manually before calling this.
-    fn de_init()
-    {
-        // de_init'ing more than once can cause a double-free -- do not want.
-        if !PhysFSContext::is_init() { return; }
-        unsafe {
-            PHYSFS_deinit();
-        }
-    }
-    /// Adds an archive or directory to the search path.
-    /// mount_point is the location in the tree to mount it to.
-    pub fn mount(&self, new_dir: &Path, mount_point: String, append_to_path: bool) -> Result<()>
-    {
-        let _g = PHYSFS_LOCK.lock();
-        let c_new_dir = CString::from_slice(new_dir.to_str().unwrap().as_bytes());
-        let c_mount_point = CString::from_slice(mount_point.as_bytes());
-        match unsafe {
-            PHYSFS_mount(
-                c_new_dir.as_ptr(),
-                c_mount_point.as_ptr(),
-                append_to_path as c_int
-            )
-        } {
-            0 => Err(util::physfs_error_as_io_error()),
-            _ => Ok(())
-        }
-    }
-
-    /// Gets the last error message in a human-readable format
-    /// This message may be localized, so do not expect it to
-    /// match a specific string of characters.
-    pub fn get_last_error() -> Option<String> {
-        let ptr: *const c_char = unsafe {
-            PHYSFS_getLastError()
-        };
-        if ptr.is_null() {
-            return None
-        }
-
-        let buf: &[u8] = unsafe { c_str_to_bytes(&ptr) };
-        let err = String::from_utf8(buf.to_vec()).unwrap();
-        Some(err)
-    }
-
-    /// Sets a new write directory.
-    /// This method will fail if the current write dir
-    /// still has open files in it.
-    pub fn set_write_dir(&self, write_dir: &Path) -> Result<()> {
-        let _g = PHYSFS_LOCK.lock();
-        let write_dir = CString::from_slice(write_dir.to_str().unwrap().as_bytes());
-        let ret = unsafe {
-            PHYSFS_setWriteDir(write_dir.as_ptr())
-        };
-
-        match ret {
-            0 => Err(util::physfs_error_as_io_error()),
-            _ => Ok(())
-        }
-    }
-
-    /// Creates a new dir relative to the write_dir.
-    pub fn mkdir(&self, dir_name: &str) -> Result<()> {
-        let _g = PHYSFS_LOCK.lock();
-        let c_dir_name = CString::from_slice(dir_name.as_bytes());
-        let ret = unsafe {
-            PHYSFS_mkdir(c_dir_name.as_ptr())
-        };
-
-        match ret {
-            0 => Err(util::physfs_error_as_io_error()),
-            _ => Ok(())
-        }
-    }
-
-    /// Checks if given path exists
-    pub fn exists(&self, path: &str) -> Result<()> {
-        let _g = PHYSFS_LOCK.lock();
-        let c_path = CString::from_slice(path.as_bytes());
-        let ret = unsafe { PHYSFS_exists(c_path.as_ptr()) };
-
-        match ret {
-            0 => Err(util::physfs_error_as_io_error()),
-            _ => Ok(())
-        }
-    }
-
-    /// Checks if given path is a directory
-    pub fn is_directory(&self, path: &str) -> Result<()> {
-        let _g = PHYSFS_LOCK.lock();
-        let c_path = CString::from_slice(path.as_bytes());
-        let ret = unsafe { PHYSFS_isDirectory(c_path.as_ptr()) };
-
-        match ret {
-            0 => Err(util::physfs_error_as_io_error()),
-            _ => Ok(())
-        }
+    match ret {
+        0 => Err(util::physfs_error_as_io_error()),
+        _ => Ok(())
     }
 }
 
-impl Drop for PhysFSContext {
-    fn drop(&mut self) {
-        // grab the lock before doing any of this!
-        let _g = PHYSFS_LOCK.lock();
+/// Checks if PhysFS is initialized.
+pub fn is_init() -> bool
+{
+    unsafe { PHYSFS_isInit() != 0 }
+}
 
-        // decrement NUM_CONTEXTS
-        unsafe {
-            NUM_CONTEXTS -= 1;
-        }
-        // and de_init if there aren't any contexts left.
-        if unsafe { NUM_CONTEXTS == 0 } {
-            PhysFSContext::de_init();
-        }
+/// De-initializes PhysFS.
+/// It is recommended to close all file handles manually before calling this.
+pub fn deinit()
+{
+    // de_init'ing more than once can cause a double-free -- do not want.
+    if !is_init() { return; }
+    unsafe { PHYSFS_deinit(); }
+}
+
+/// Adds an archive or directory to the search path.
+/// mount_point is the location in the tree to mount it to.
+pub fn mount(new_dir: &Path, mount_point: String, append_to_path: bool) -> Result<()>
+{
+    let c_new_dir = CString::new(new_dir.to_str().unwrap().as_bytes()).unwrap();
+    let c_mount_point = CString::new(mount_point.as_bytes()).unwrap();
+
+    let ret = unsafe {
+        PHYSFS_mount(
+            c_new_dir.as_ptr(),
+            c_mount_point.as_ptr(),
+            append_to_path as c_int
+        )
+    };
+
+    match ret {
+        0 => Err(util::physfs_error_as_io_error()),
+        _ => Ok(())
+    }
+}
+
+/// Gets the last error message in a human-readable format.
+/// This message may be localized, so do not expect it to match a specific string of characters.
+pub fn get_last_error() -> Option<String> {
+    let ptr: *const c_char = unsafe { PHYSFS_getLastError() };
+
+    if ptr.is_null() {
+        return None
+    }
+
+    let buf = unsafe { CStr::from_ptr(ptr).to_bytes() };
+    let err = String::from_utf8(buf.to_vec()).unwrap();
+    Some(err)
+}
+
+/// Sets a new write directory.
+/// This method will fail if the current write dir still has open files in it.
+pub fn set_write_dir(write_dir: &Path) -> Result<()> {
+    let write_dir = CString::new(write_dir.to_str().unwrap().as_bytes()).unwrap();
+
+    let ret = unsafe { PHYSFS_setWriteDir(write_dir.as_ptr()) };
+
+    match ret {
+        0 => Err(util::physfs_error_as_io_error()),
+        _ => Ok(())
+    }
+}
+
+/// Creates a new dir relative to the write_dir.
+pub fn mkdir(dir_name: &str) -> Result<()> {
+    let c_dir_name = CString::new(dir_name.as_bytes()).unwrap();
+
+    let ret = unsafe { PHYSFS_mkdir(c_dir_name.as_ptr()) };
+
+    match ret {
+        0 => Err(util::physfs_error_as_io_error()),
+        _ => Ok(())
+    }
+}
+
+/// Checks if given path exists.
+pub fn exists(path: &str) -> Result<()> {
+    let c_path = CString::new(path.as_bytes()).unwrap();
+
+    let ret = unsafe { PHYSFS_exists(c_path.as_ptr()) };
+
+    match ret {
+        0 => Err(util::physfs_error_as_io_error()),
+        _ => Ok(())
+    }
+}
+
+/// Checks if given path is a directory.
+pub fn is_directory(path: &str) -> Result<()> {
+    let c_path = CString::new(path.as_bytes()).unwrap();
+
+    let ret = unsafe { PHYSFS_isDirectory(c_path.as_ptr()) };
+
+    match ret {
+        0 => Err(util::physfs_error_as_io_error()),
+        _ => Ok(())
     }
 }
 

--- a/src/physfs/util.rs
+++ b/src/physfs/util.rs
@@ -1,9 +1,9 @@
 use std::io::{Error, ErrorKind};
-use super::PhysFSContext;
+use super::get_last_error;
 
 pub fn physfs_error_as_io_error() -> Error {
     Error::new(ErrorKind::Other,
                "PhysicsFS Error",
-               PhysFSContext::get_last_error())
+               get_last_error())
 }
 

--- a/tests/directory/mod.rs
+++ b/tests/directory/mod.rs
@@ -1,26 +1,24 @@
 use std::io::Read;
 use std::path::Path;
 
-use physfs::PhysFSContext;
-use physfs::file;
-use super::TEST_LOCK;
+use physfs;
+use physfs::{File, Mode};
 
 #[test]
 fn read_file_from_directory() {
-    let _g = TEST_LOCK.lock();
-    let con = match PhysFSContext::new() {
+    match physfs::init() {
         Err(e) => panic!(e),
-        Ok(con) => con
+        Ok(_) => {}
     };
 
-    assert!(PhysFSContext::is_init());
+    assert!(physfs::is_init());
 
-    match con.mount(Path::new(super::PATH_TO_HERE), "/test/".to_string(), true) {
+    match physfs::mount(Path::new(super::PATH_TO_HERE), "/test/".to_string(), true) {
         Err(e) => panic!(e),
         _ => {}
     }
 
-    let mut file = match file::File::open(&con, "/test/directory/read.txt".to_string(), file::Mode::Read) {
+    let mut file = match File::open("/test/directory/read.txt".to_string(), Mode::Read) {
         Ok(f) => f,
         Err(e) => panic!(e)
     };

--- a/tests/directory/mod.rs
+++ b/tests/directory/mod.rs
@@ -3,9 +3,12 @@ use std::path::Path;
 
 use physfs;
 use physfs::{File, Mode};
+use super::TEST_LOCK;
 
 #[test]
 fn read_file_from_directory() {
+    let _g = TEST_LOCK.lock();
+
     match physfs::init() {
         Err(e) => panic!(e),
         Ok(_) => {}
@@ -38,5 +41,14 @@ fn read_file_from_directory() {
     }
 
     assert!(contents.as_slice() == "Read from me.");
+
+    match file.close() {
+        Err(e) => panic!(e),
+        Ok(_) => {}
+    };
+
+    physfs::deinit();
+
+    assert!(!physfs::is_init());
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,43 +1,21 @@
 #![feature(core)]
 #![feature(io)]
 #![feature(path)]
-#![feature(std_misc)]
 
 extern crate physfs;
 
-use std::thread::Thread;
-use physfs::*;
-use std::sync::{StaticMutex, MUTEX_INIT};
-
 mod directory;
-
-/// For running only one test at a time
-static TEST_LOCK: StaticMutex = MUTEX_INIT;
 
 // from project_root
 static PATH_TO_HERE: &'static str = "tests/";
 
 #[test]
-fn test_create_physfs_context() {
-    let _g = TEST_LOCK.lock();
-    let con = PhysFSContext::new().unwrap();
-    let _ = con;
-    assert!(PhysFSContext::is_init());
-}
+fn test_init_physfs() {
+    match physfs::init() {
+        Err(e) => panic!(e),
+        Ok(_) => {}
+    };
 
-#[test]
-fn test_threaded_physfs_contexts() {
-    let _g = TEST_LOCK.lock();
-    let threads: Vec<_> = range(0is, 10).map(|_| {
-        Thread::scoped(move || {
-            let con = PhysFSContext::new().unwrap();
-            let _ = con;
-            assert!(PhysFSContext::is_init())
-        })
-    }).collect();
-
-    for thread in threads.into_iter() {
-        let _ = thread.join();
-    }
+    assert!(physfs::is_init());
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,21 +1,33 @@
 #![feature(core)]
 #![feature(io)]
 #![feature(path)]
+#![feature(std_misc)]
 
 extern crate physfs;
 
+use std::sync::{StaticMutex, MUTEX_INIT};
+
 mod directory;
+
+/// For running only one test at a time
+static TEST_LOCK: StaticMutex = MUTEX_INIT;
 
 // from project_root
 static PATH_TO_HERE: &'static str = "tests/";
 
 #[test]
 fn test_init_physfs() {
+    let _g = TEST_LOCK.lock();
+
     match physfs::init() {
         Err(e) => panic!(e),
         Ok(_) => {}
     };
 
     assert!(physfs::is_init());
+
+    physfs::deinit();
+
+    assert!(!physfs::is_init());
 }
 


### PR DESCRIPTION
**NOTE: Not ready to be merged. Submitting PR for purposes of discussion.**

As per discussion in #2:
* Remove PhysFSContext as it gives the false illusion of being able to have multiple independent contexts.
* Remove static mutext as (non-File) PhysFS methods are thread-safe.
* Add per-File mutex for thread safety.

Also
* Update `ffi` calls to latest rust
 * `CString::from_slice` -> `CString::new`
 * `c_str_to_bytes` -> `CStr::from_ptr`

**TODO**
* Investigate which tests can and can't be run in parallel.
 * Probably implement a setup/teardown so that all tests can be run in parallel.